### PR TITLE
Support child component re-render and unmounting

### DIFF
--- a/src/TransitionBase.js
+++ b/src/TransitionBase.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 
 export class TransitionBase extends Component {
   defer = [];
+  mounted = false;
 
   deferParent(func) {
     this.defer.push(func);
@@ -9,7 +10,7 @@ export class TransitionBase extends Component {
 
   wrapChild(child) {
     return React.cloneElement(child, {
-      parent: this.native,
+      parent: this,
       onParentMount: this.deferParent.bind(this)
     });
   }
@@ -23,9 +24,20 @@ export class TransitionBase extends Component {
   }
 
   mount() {
-    if (this.props.onParentMount && this.props.parent)
-      this.props.onParentMount(() => this.props.parent.add(this.native));
+    if (this.props.parent)
+      if (this.props.parent.mounted)
+        this.props.parent.native.add(this.native);
+      else if (this.props.onParentMount)
+        this.props.onParentMount(() => this.props.parent.native.add(this.native));
 
     this.defer.forEach(func => func());
+    this.mounted = true;
+  }
+
+  unmount() {
+    if (this.props.parent)
+      this.props.parent.native.remove(this.native);
+    
+    this.mounted = false;
   }
 }

--- a/src/reactify.js
+++ b/src/reactify.js
@@ -18,5 +18,9 @@ export function reactify(component) {
     componentDidMount() {
       this.mount();
     }
+
+    componentWillUnmount() {
+      this.unmount();
+    }
   }
 }


### PR DESCRIPTION
These changes allow child components in the App to be re rendered during state or prop changes. In addition, support for destroying objects from Scene when child components are unmounted.

I have a working example using the feature: https://github.com/psychobolt/whitestorm-react-electron-boilerplate.